### PR TITLE
getRedirectResult() が終わってから ready が発火するよう対応

### DIFF
--- a/src/async-event-emitter.js
+++ b/src/async-event-emitter.js
@@ -1,0 +1,25 @@
+const EventEmitter = require('events');
+
+class AsyncEventEmitter extends EventEmitter {
+  constructor() {
+    super();
+  }
+
+  // 非同期版 emit
+  emitAsync(event, ...args) {
+    let promises = [];
+    
+    this.listeners(event).forEach(listener => {
+      var res = listener(...args);
+      promises.push(res);
+
+      // if (res instanceof Promise) {
+      //   promises.push(res);
+      // }
+    });
+
+    return Promise.all(promises);
+  }
+}
+
+module.exports = AsyncEventEmitter;

--- a/src/auth.js
+++ b/src/auth.js
@@ -10,7 +10,7 @@ class Auth extends AsyncEventEmitter {
     this.auth = firebase.auth();
 
     // redirect result を取得
-    var result = await this.auth.getRedirectResult().catch(() => {
+    var result = await this.auth.getRedirectResult().catch((e) => {
       var message = this._codeToErrorMessage(e.code);
       e.message = message;
   
@@ -18,7 +18,7 @@ class Auth extends AsyncEventEmitter {
     });
 
     // user があれば signin を発火
-    if (result.user) {
+    if (result && result.user) {
       await this.emitAsync('signin', result);
     }
     

--- a/src/auth.js
+++ b/src/auth.js
@@ -6,7 +6,6 @@ class Auth extends AsyncEventEmitter {
   }
 
   async init(firebase) {
-    debugger;
     this.firebase = firebase;
     this.auth = firebase.auth();
 


### PR DESCRIPTION
SNS ログイン時とかに signup が終わってないのに ready が発火するケースがあったのでそれを防ぐために
必ず getRedirectResult() を実行し, `signin` イベントの処理がすべて終わってから `ready` を発火するよう対応